### PR TITLE
Don't fail if there is no org-pretty-table library

### DIFF
--- a/dired-auto-readme.el
+++ b/dired-auto-readme.el
@@ -239,7 +239,7 @@ This function assumes the content is not currently inserted."
   (org-toggle-pretty-entities)
   (setq org-link-descriptive t)
   (when (and dired-auto-readme-display-pretty-tables
-             (require 'org-pretty-table))
+             (require 'org-pretty-table nil t))
     (org-pretty-table-mode 1))
   (require 'package)
   (and (package-installed-p 'org-view-mode)


### PR DESCRIPTION
According to the readme, `org-pretty-table` seems to be an optional dependency of this package, so it should not fail if the package is not installed. The error can be prevented by setting `NOERROR` argument of `require`.