### PR TITLE
fixes font-lock-mode: Wrong number of arguments: #<subr dired-auto-re…

### DIFF
--- a/dired-auto-readme.el
+++ b/dired-auto-readme.el
@@ -61,7 +61,7 @@ These hooks are called after the major mode is set and font-lock is enabled."
 (defvar-local dired-auto-readme--inserted nil)
 (defvar-local dired-auto-readme--readme-buff nil)
 
-(defun dired-auto-readme--font-lock-fn ()
+(defun dired-auto-readme--font-lock-fn (&optional interactively)
   "Dired-auto-readme `font-lock-fn'.
 Argument FL Same as in `font-lock-fontify-buffer' function."
   (dired-auto-readme--fontify-buffer))


### PR DESCRIPTION
Without this change I am not able to use dired-auto-readme with Emacs 28.2